### PR TITLE
Cross-compile standard compatibility.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Cross Compile Compatibility
+if (MSVC)
 SET(CMAKE_CXX_FLAGS "/permissive-")
+endif()
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()


### PR DESCRIPTION
Small change to force IntelliSense to see MSVC specific features as errors.